### PR TITLE
Facilitate builds on systems with non-standard installations of Slurm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,6 @@ all : sps launch_sps
 sps : sps.cpp 
 	g++ -Wall -Wextra -Wpedantic -Werror -std=c++17 -O3 -o sps sps.cpp 
 launch_sps : launch_sps.c
-	gcc -Wall -Wextra -Wpedantic -Werror -shared -fPIC -o launch_sps.so launch_sps.c
+	gcc $(CFLAGS) -Wall -Wextra -Wpedantic -Werror -shared -fPIC -o launch_sps.so launch_sps.c
 clean :
 	rm launch_sps.so sps


### PR DESCRIPTION
When Slurm is not installed in a standard location compilation of launch_sps fails because "slurm/spank.h" is not found. With this change
  `CFLAGS=/path/to/slurm/include make`
is possible and solves that problem.