### PR TITLE
Fix compile errors in newer gcc-versions

### DIFF
--- a/launch_sps.c
+++ b/launch_sps.c
@@ -6,9 +6,9 @@
 #include <slurm/spank.h>
 
 /* All spank plugins must define this macro for the Slurm plugin loader. */
-SPANK_PLUGIN(launch_sps, 1);
+SPANK_PLUGIN(launch_sps, 1)
 
-int slurm_spank_task_init (spank_t sp, int ac, char **av)
+int slurm_spank_task_init (spank_t sp, int ac __attribute__((unused)), char **av __attribute__((unused)))
 {
     int taskid;
     spank_get_item (sp, S_JOB_ID, &taskid);


### PR DESCRIPTION
Newer versions of gcc (> 10) complain about:
* `ISO C does not allow extra ';' outside of a function`
* `unused parameter 'ac'` and `unused parameter 'av'`